### PR TITLE
Convert AMD to es6 modules

### DIFF
--- a/js/bootstrapper.js
+++ b/js/bootstrapper.js
@@ -15,24 +15,14 @@
  | See the License for the specific language governing permissions and
  | limitations under the License.
  */
-define([
-    "dojo/_base/declare",
-    "config/template-config",
-    "application/template",
-    "widgets/sign-in/sign-in",
-    "application/utils/utils",
-    "dojo/dom-construct",
-    "dojo/_base/lang"
-], function (
-    declare,
-    TemplateConfig,
-    Template,
-    ApplicationSignIn,
-    ApplicationUtils,
-    domConstruct,
-    lang
-) {
-    return declare(null, {
+import declare from "dojo/_base/declare";
+import TemplateConfig from "config/template-config";
+import Template from "application/template";
+import ApplicationSignIn from "widgets/sign-in/sign-in";
+import ApplicationUtils from "application/utils/utils";
+import domConstruct from "dojo/dom-construct";
+import lang from "dojo/_base/lang";
+    export default declare(null, {
         boilerPlateTemplateObject: null,
         appUtils: null,
 
@@ -128,4 +118,4 @@ define([
             document.getElementsByTagName('head')[0].appendChild(icon);
         }
     });
-});
+

--- a/js/bootstrapper.js
+++ b/js/bootstrapper.js
@@ -18,8 +18,8 @@
 import declare from "dojo/_base/declare";
 import TemplateConfig from "config/template-config";
 import Template from "application/template";
-import ApplicationSignIn from "widgets/sign-in/sign-in";
-import ApplicationUtils from "application/utils/utils";
+import ApplicationSignIn from "./widgets/sign-in/sign-in";
+import ApplicationUtils from "./utils/utils";
 import domConstruct from "dojo/dom-construct";
 import lang from "dojo/_base/lang";
     export default declare(null, {
@@ -118,4 +118,3 @@ import lang from "dojo/_base/lang";
             document.getElementsByTagName('head')[0].appendChild(icon);
         }
     });
-

--- a/js/main.js
+++ b/js/main.js
@@ -51,16 +51,16 @@ import geometryEngine from "esri/geometry/geometryEngine";
 import webMercatorUtils from "esri/geometry/webMercatorUtils";
 import PopupTemplate from "esri/dijit/PopupTemplate";
 import Draw from "esri/toolbars/draw";
-import ApplicationHeader from "widgets/app-header/app-header";
-import WebMapList from "widgets/webmap-list/webmap-list";
-import IssueWall from "widgets/issue-wall/issue-wall";
-import GeoForm from "widgets/geo-form/geo-form";
-import MyIssues from "widgets/my-issues/my-issues";
+import ApplicationHeader from "./widgets/app-header/app-header";
+import WebMapList from "./widgets/webmap-list/webmap-list";
+import IssueWall from "./widgets/issue-wall/issue-wall";
+import GeoForm from "./widgets/geo-form/geo-form";
+import MyIssues from "./widgets/my-issues/my-issues";
 import ApplicationUtils from "application/utils/utils";
 import query from "dojo/query";
-import SidebarContentController from "widgets/sidebar-content-controller/sidebar-content-controller";
-import ItemDetails from "widgets/item-details/item-details-controller";
-import MapSearch from "widgets/map-search/map-search";
+import SidebarContentController from "./widgets/sidebar-content-controller/sidebar-content-controller";
+import ItemDetails from "./widgets/item-details/item-details-controller";
+import MapSearch from "./widgets/map-search/map-search";
 import "dojo/domReady!";
     export default declare(null, {
         config: {},

--- a/js/main.js
+++ b/js/main.js
@@ -15,103 +15,54 @@
 | See the License for the specific language governing permissions and
 | limitations under the License.
 */
-define([
-    "dojo/_base/declare",
-    "dojo/_base/lang",
-    "dojo/_base/array",
-    "esri/arcgis/utils",
-    "dojo/dom",
-    "dojo/dom-construct",
-    "dojo/dom-style",
-    "dojo/dom-class",
-    "dojo/dom-attr",
-    "dojo/on",
-    "dojo/topic",
-    "dojo/string",
-    "dojo/touch",
-    "dojo/window",
-    "dojo/aspect",
-    "dojo/Deferred",
-    "dojo/text!css/theme-template.css",
-    "esri/layers/GraphicsLayer",
-    "esri/layers/FeatureLayer",
-    "esri/geometry/Circle",
-    "esri/tasks/query",
-    "esri/Color",
-    "esri/graphic",
-    "esri/geometry/Point",
-    "esri/geometry/Polyline",
-    "esri/geometry/Polygon",
-    "esri/SpatialReference",
-    "esri/symbols/SimpleMarkerSymbol",
-    "esri/symbols/SimpleLineSymbol",
-    "esri/symbols/SimpleFillSymbol",
-    "esri/symbols/PictureMarkerSymbol",
-    "esri/tasks/QueryTask",
-    "esri/geometry/geometryEngine",
-    "esri/geometry/webMercatorUtils",
-    "esri/dijit/PopupTemplate",
-    "esri/toolbars/draw",
-    "widgets/app-header/app-header",
-    "widgets/webmap-list/webmap-list",
-    "widgets/issue-wall/issue-wall",
-    "widgets/geo-form/geo-form",
-    "widgets/my-issues/my-issues",
-    "application/utils/utils",
-    "dojo/query",
-    "widgets/sidebar-content-controller/sidebar-content-controller",
-    "widgets/item-details/item-details-controller",
-    "widgets/map-search/map-search",
-    "dojo/domReady!"
-], function (
-    declare,
-    lang,
-    array,
-    arcgisUtils,
-    dom,
-    domConstruct,
-    domStyle,
-    domClass,
-    domAttr,
-    on,
-    topic,
-    string,
-    touch,
-    dojowindow,
-    aspect,
-    Deferred,
-    ThemeCss,
-    GraphicsLayer,
-    FeatureLayer,
-    Circle,
-    Query,
-    Color,
-    Graphic,
-    Point,
-    Polyline,
-    Polygon,
-    SpatialReference,
-    SimpleMarkerSymbol,
-    SimpleLineSymbol,
-    SimpleFillSymbol,
-    PictureMarkerSymbol,
-    QueryTask,
-    geometryEngine,
-    webMercatorUtils,
-    PopupTemplate,
-    Draw,
-    ApplicationHeader,
-    WebMapList,
-    IssueWall,
-    GeoForm,
-    MyIssues,
-    ApplicationUtils,
-    query,
-    SidebarContentController,
-    ItemDetails,
-    MapSearch
-) {
-    return declare(null, {
+import declare from "dojo/_base/declare";
+import lang from "dojo/_base/lang";
+import array from "dojo/_base/array";
+import arcgisUtils from "esri/arcgis/utils";
+import dom from "dojo/dom";
+import domConstruct from "dojo/dom-construct";
+import domStyle from "dojo/dom-style";
+import domClass from "dojo/dom-class";
+import domAttr from "dojo/dom-attr";
+import on from "dojo/on";
+import topic from "dojo/topic";
+import string from "dojo/string";
+import touch from "dojo/touch";
+import dojowindow from "dojo/window";
+import aspect from "dojo/aspect";
+import Deferred from "dojo/Deferred";
+import ThemeCss from "dojo/text!css/theme-template.css";
+import GraphicsLayer from "esri/layers/GraphicsLayer";
+import FeatureLayer from "esri/layers/FeatureLayer";
+import Circle from "esri/geometry/Circle";
+import Query from "esri/tasks/query";
+import Color from "esri/Color";
+import Graphic from "esri/graphic";
+import Point from "esri/geometry/Point";
+import Polyline from "esri/geometry/Polyline";
+import Polygon from "esri/geometry/Polygon";
+import SpatialReference from "esri/SpatialReference";
+import SimpleMarkerSymbol from "esri/symbols/SimpleMarkerSymbol";
+import SimpleLineSymbol from "esri/symbols/SimpleLineSymbol";
+import SimpleFillSymbol from "esri/symbols/SimpleFillSymbol";
+import PictureMarkerSymbol from "esri/symbols/PictureMarkerSymbol";
+import QueryTask from "esri/tasks/QueryTask";
+import geometryEngine from "esri/geometry/geometryEngine";
+import webMercatorUtils from "esri/geometry/webMercatorUtils";
+import PopupTemplate from "esri/dijit/PopupTemplate";
+import Draw from "esri/toolbars/draw";
+import ApplicationHeader from "widgets/app-header/app-header";
+import WebMapList from "widgets/webmap-list/webmap-list";
+import IssueWall from "widgets/issue-wall/issue-wall";
+import GeoForm from "widgets/geo-form/geo-form";
+import MyIssues from "widgets/my-issues/my-issues";
+import ApplicationUtils from "application/utils/utils";
+import query from "dojo/query";
+import SidebarContentController from "widgets/sidebar-content-controller/sidebar-content-controller";
+import ItemDetails from "widgets/item-details/item-details-controller";
+import MapSearch from "widgets/map-search/map-search";
+import "dojo/domReady!";
+    export default declare(null, {
         config: {},
         appUtils: null,
         boilerPlateTemplate: null,
@@ -2322,4 +2273,3 @@ define([
         }
         /*-------  End of section for Geographical Filtering  -------*/
     });
-});

--- a/js/template.js
+++ b/js/template.js
@@ -38,7 +38,7 @@ import esriPortal from "esri/arcgis/Portal";
 import ArcGISOAuthInfo from "esri/arcgis/OAuthInfo";
 import arcgisUtils from "esri/arcgis/utils";
 import GeometryService from "esri/tasks/GeometryService";
-import defaults from "config/defaults";
+import defaults from "../defaults";
   export default declare([Evented], {
     config: {},
     orgConfig: {},

--- a/js/template.js
+++ b/js/template.js
@@ -20,44 +20,26 @@
  | See the License for the specific language governing permissions and
  | limitations under the License.
  */
-define([
-  "dojo/_base/array",
-  "dojo/_base/declare",
-  "dojo/_base/kernel",
-  "dojo/_base/lang",
-
-  "dojo/Evented",
-  "dojo/Deferred",
-  "dojo/string",
-
-  "dojo/dom-class",
-
-  "dojo/promise/all",
-
-  "esri/config",
-  "esri/IdentityManager",
-  "esri/lang",
-  "esri/request",
-  "esri/urlUtils",
-
-  "esri/arcgis/Portal",
-  "esri/arcgis/OAuthInfo",
-  "esri/arcgis/utils",
-
-  "esri/tasks/GeometryService",
-
-  "config/defaults"
-], function (
-  array, declare, kernel, lang,
-  Evented, Deferred, string,
-  domClass,
-  all,
-  esriConfig, IdentityManager, esriLang, esriRequest, urlUtils,
-  esriPortal, ArcGISOAuthInfo, arcgisUtils,
-  GeometryService,
-  defaults
-) {
-  return declare([Evented], {
+import array from "dojo/_base/array";
+import declare from "dojo/_base/declare";
+import kernel from "dojo/_base/kernel";
+import lang from "dojo/_base/lang";
+import Evented from "dojo/Evented";
+import Deferred from "dojo/Deferred";
+import string from "dojo/string";
+import domClass from "dojo/dom-class";
+import all from "dojo/promise/all";
+import esriConfig from "esri/config";
+import IdentityManager from "esri/IdentityManager";
+import esriLang from "esri/lang";
+import esriRequest from "esri/request";
+import urlUtils from "esri/urlUtils";
+import esriPortal from "esri/arcgis/Portal";
+import ArcGISOAuthInfo from "esri/arcgis/OAuthInfo";
+import arcgisUtils from "esri/arcgis/utils";
+import GeometryService from "esri/tasks/GeometryService";
+import defaults from "config/defaults";
+  export default declare([Evented], {
     config: {},
     orgConfig: {},
     appConfig: {},
@@ -556,4 +538,3 @@ define([
       return deferred.promise;
     }
   });
-});

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -15,48 +15,26 @@
 | See the License for the specific language governing permissions and
 | limitations under the License.
 */
-define([
-    "dojo/_base/declare",
-    "dojo/dom",
-    "dojo/_base/fx",
-    "dojo/_base/lang",
-    "dojo/_base/array",
-    "dojo/dom-construct",
-    "dojo/dom-geometry",
-    "dojo/dom-class",
-    "dojo/dom-attr",
-    "dojo/dom-style",
-    "dojo/on",
-    "dojo/has",
-    "dojo/query",
-    "dijit/_WidgetBase",
-    "esri/dijit/LocateButton",
-    "esri/dijit/HomeButton",
-    "esri/tasks/locator",
-    "esri/geometry/webMercatorUtils",
-    "dojo/Deferred"
-], function (
-    declare,
-    dom,
-    coreFx,
-    lang,
-    array,
-    domConstruct,
-    domGeometry,
-    domClass,
-    domAttr,
-    domStyle,
-    on,
-    has,
-    query,
-    _WidgetBase,
-    LocateButton,
-    HomeButton,
-    Locator,
-    webMercatorUtils,
-    Deferred
-) {
-    return declare([_WidgetBase], {
+import declare from "dojo/_base/declare";
+import dom from "dojo/dom";
+import coreFx from "dojo/_base/fx";
+import lang from "dojo/_base/lang";
+import array from "dojo/_base/array";
+import domConstruct from "dojo/dom-construct";
+import domGeometry from "dojo/dom-geometry";
+import domClass from "dojo/dom-class";
+import domAttr from "dojo/dom-attr";
+import domStyle from "dojo/dom-style";
+import on from "dojo/on";
+import has from "dojo/has";
+import query from "dojo/query";
+import _WidgetBase from "dijit/_WidgetBase";
+import LocateButton from "esri/dijit/LocateButton";
+import HomeButton from "esri/dijit/HomeButton";
+import Locator from "esri/tasks/locator";
+import webMercatorUtils from "esri/geometry/webMercatorUtils";
+import Deferred from "dojo/Deferred";
+    export default declare([_WidgetBase], {
         showLoadingIndicator: function () {
             domClass.add(document.body, "app-loading");
         },
@@ -290,4 +268,3 @@ define([
             }));
         }
     });
-});

--- a/js/widgets/app-header/app-header.js
+++ b/js/widgets/app-header/app-header.js
@@ -25,8 +25,8 @@ import domClass from "dojo/dom-class";
 import domStyle from "dojo/dom-style";
 import on from "dojo/on";
 import template from "dojo/text!./templates/app-header.html";
-import MobileMenu from "widgets/mobile-menu/mobile-menu";
-import Help from "widgets/help/help";
+import MobileMenu from "../mobile-menu/mobile-menu";
+import Help from "../help/help";
 import _WidgetBase from "dijit/_WidgetBase";
 import _TemplatedMixin from "dijit/_TemplatedMixin";
 import _WidgetsInTemplateMixin from "dijit/_WidgetsInTemplateMixin";
@@ -312,4 +312,3 @@ import _WidgetsInTemplateMixin from "dijit/_WidgetsInTemplateMixin";
             return evt;
         }
     });
-

--- a/js/widgets/app-header/app-header.js
+++ b/js/widgets/app-header/app-header.js
@@ -16,23 +16,21 @@
  | limitations under the License.
  */
 //============================================================================================================================//
-define([
-    "dojo/_base/declare",
-    "dojo/dom-construct",
-    "dojo/_base/lang",
-    "dojo/dom",
-    "dojo/dom-attr",
-    "dojo/dom-class",
-    "dojo/dom-style",
-    "dojo/on",
-    "dojo/text!./templates/app-header.html",
-    "widgets/mobile-menu/mobile-menu",
-    "widgets/help/help",
-    "dijit/_WidgetBase",
-    "dijit/_TemplatedMixin",
-    "dijit/_WidgetsInTemplateMixin"
-], function (declare, domConstruct, lang, dom, domAttr, domClass, domStyle, on, template, MobileMenu, Help, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin) {
-    return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
+import declare from "dojo/_base/declare";
+import domConstruct from "dojo/dom-construct";
+import lang from "dojo/_base/lang";
+import dom from "dojo/dom";
+import domAttr from "dojo/dom-attr";
+import domClass from "dojo/dom-class";
+import domStyle from "dojo/dom-style";
+import on from "dojo/on";
+import template from "dojo/text!./templates/app-header.html";
+import MobileMenu from "widgets/mobile-menu/mobile-menu";
+import Help from "widgets/help/help";
+import _WidgetBase from "dijit/_WidgetBase";
+import _TemplatedMixin from "dijit/_TemplatedMixin";
+import _WidgetsInTemplateMixin from "dijit/_WidgetsInTemplateMixin";
+    export default declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
         templateString: template,
         mobileMenu: null,
         config: {
@@ -314,4 +312,4 @@ define([
             return evt;
         }
     });
-});
+

--- a/js/widgets/bootstrapmap/bootstrapmap.js
+++ b/js/widgets/bootstrapmap/bootstrapmap.js
@@ -1,21 +1,19 @@
-define([
-    "esri/map",
-    "esri/arcgis/utils",
-    "esri/geometry/Point",
-    "dojo/_base/declare",
-    "dojo/on",
-    "dojo/touch",
-    "dojo/dom",
-    "dojo/_base/lang",
-    "dojo/dom-style",
-    "dojo/query",
-    "dojo/NodeList-traverse",
-    "dojo/dom-class",
-    "dojo/domReady!"],
-    function (Map, EsriUtils, Point, declare, on, touch, dom, lang, style, query, nodecols, domClass) {
-        "use strict";
+import Map from "esri/map";
+import EsriUtils from "esri/arcgis/utils";
+import Point from "esri/geometry/Point";
+import declare from "dojo/_base/declare";
+import on from "dojo/on";
+import touch from "dojo/touch";
+import dom from "dojo/dom";
+import lang from "dojo/_base/lang";
+import style from "dojo/dom-style";
+import query from "dojo/query";
+import nodecols from "dojo/NodeList-traverse";
+import domClass from "dojo/dom-class";
+import "dojo/domReady!";
+        
 
-        return {
+        export default {
             // BootstrapMap Class Public Functions
             create: function (divId, options) {
                 var smartResizer,
@@ -397,4 +395,4 @@ define([
                 }
             }) // _smartResizer
         }; // return
-    }); // define function
+     // define function

--- a/js/widgets/comment-form/comment-form.js
+++ b/js/widgets/comment-form/comment-form.js
@@ -15,46 +15,25 @@
 | See the License for the specific language governing permissions and
 | limitations under the License.
 */
-define([
-    "dojo/_base/declare",
-    "dijit/_WidgetBase",
-    "dijit/_TemplatedMixin",
-    "dojo/_base/lang",
-    "dojo/_base/array",
-    "dojo/_base/kernel",
-    "dojo/dom-construct",
-    "dojo/dom-class",
-    "dojo/dom-style",
-    "dojo/query",
-    "dojo/dom",
-    "dojo/string",
-    "dojo/on",
-    'dojo/dom-attr',
-    "dojo/date/locale",
-    "esri/graphic",
-    "esri/tasks/RelationshipQuery",
-    "dojo/text!./templates/comment-form.html"
-], function (
-    declare,
-    _WidgetBase,
-    _TemplatedMixin,
-    lang,
-    array,
-    kernel,
-    domConstruct,
-    domClass,
-    domStyle,
-    query,
-    dom,
-    string,
-    on,
-    domAttr,
-    locale,
-    Graphic,
-    RelationshipQuery,
-    commentForm
-) {
-    return declare([_WidgetBase, _TemplatedMixin], {
+import declare from "dojo/_base/declare";
+import _WidgetBase from "dijit/_WidgetBase";
+import _TemplatedMixin from "dijit/_TemplatedMixin";
+import lang from "dojo/_base/lang";
+import array from "dojo/_base/array";
+import kernel from "dojo/_base/kernel";
+import domConstruct from "dojo/dom-construct";
+import domClass from "dojo/dom-class";
+import domStyle from "dojo/dom-style";
+import query from "dojo/query";
+import dom from "dojo/dom";
+import string from "dojo/string";
+import on from "dojo/on";
+import domAttr from 'dojo/dom-attr';
+import locale from "dojo/date/locale";
+import Graphic from "esri/graphic";
+import RelationshipQuery from "esri/tasks/RelationshipQuery";
+import commentForm from "dojo/text!./templates/comment-form.html";
+    export default declare([_WidgetBase, _TemplatedMixin], {
         templateString: commentForm,
         sortedFields: [],
         i18n: {},
@@ -1662,4 +1641,3 @@ define([
             this.selectedLayer = selectedLayer;
         }
     });
-});

--- a/js/widgets/geo-form/geo-form.js
+++ b/js/widgets/geo-form/geo-form.js
@@ -15,38 +15,35 @@
  | See the License for the specific language governing permissions and
  | limitations under the License.
  */
-define([
-    "dojo/_base/declare",
-    "dojo/_base/kernel",
-    "dojo/_base/lang",
-    "dojo/date/locale",
-    "dijit/_WidgetBase",
-    "dijit/_TemplatedMixin",
-    "dojo/dom-construct",
-    "dojo/dom-class",
-    "dojo/on",
-    "dojo/has",
-    "dojo/dom-attr",
-    "dojo/_base/array",
-    "dojo/dom",
-    "dojo/touch",
-    "dojo/dom-style",
-    "dojo/query",
-    "dojo/text!./templates/geo-form.html",
-    "dojo/string",
-    "dojo/date/locale",
-    "esri/layers/GraphicsLayer",
-    "esri/graphic",
-    "esri/toolbars/draw",
-    "esri/geometry/webMercatorUtils",
-    "esri/symbols/SimpleLineSymbol",
-    "esri/symbols/SimpleFillSymbol",
-    "esri/symbols/SimpleMarkerSymbol",
-    "esri/geometry/Polygon",
-    "widgets/locator/locator",
-    "widgets/bootstrapmap/bootstrapmap"
-], function (declare, kernel, lang, dateLocale, _WidgetBase, _TemplatedMixin, domConstruct, domClass, on, has, domAttr, array, dom, touch, domStyle, query, dijitTemplate, string, locale, GraphicsLayer, Graphic, Draw, webMercatorUtils, SimpleLineSymbol, SimpleFillSymbol, SimpleMarkerSymbol, Polygon, Locator, BootstrapMap) {
-    return declare([_WidgetBase, _TemplatedMixin], {
+import declare from "dojo/_base/declare";
+import kernel from "dojo/_base/kernel";
+import lang from "dojo/_base/lang";
+import locale from "dojo/date/locale";
+import _WidgetBase from "dijit/_WidgetBase";
+import _TemplatedMixin from "dijit/_TemplatedMixin";
+import domConstruct from "dojo/dom-construct";
+import domClass from "dojo/dom-class";
+import on from "dojo/on";
+import has from "dojo/has";
+import domAttr from "dojo/dom-attr";
+import array from "dojo/_base/array";
+import dom from "dojo/dom";
+import touch from "dojo/touch";
+import domStyle from "dojo/dom-style";
+import query from "dojo/query";
+import dijitTemplate from "dojo/text!./templates/geo-form.html";
+import string from "dojo/string";
+import GraphicsLayer from "esri/layers/GraphicsLayer";
+import Graphic from "esri/graphic";
+import Draw from "esri/toolbars/draw";
+import webMercatorUtils from "esri/geometry/webMercatorUtils";
+import SimpleLineSymbol from "esri/symbols/SimpleLineSymbol";
+import SimpleFillSymbol from "esri/symbols/SimpleFillSymbol";
+import SimpleMarkerSymbol from "esri/symbols/SimpleMarkerSymbol";
+import Polygon from "esri/geometry/Polygon";
+import Locator from "widgets/locator/locator";
+import BootstrapMap from "widgets/bootstrapmap/bootstrapmap";
+    export default declare([_WidgetBase, _TemplatedMixin], {
         templateString: dijitTemplate,
         lastWebMapSelected: "",
         sortedFields: [],
@@ -2511,4 +2508,3 @@ define([
             }
         }
     });
-});

--- a/js/widgets/geo-form/geo-form.js
+++ b/js/widgets/geo-form/geo-form.js
@@ -41,8 +41,8 @@ import SimpleLineSymbol from "esri/symbols/SimpleLineSymbol";
 import SimpleFillSymbol from "esri/symbols/SimpleFillSymbol";
 import SimpleMarkerSymbol from "esri/symbols/SimpleMarkerSymbol";
 import Polygon from "esri/geometry/Polygon";
-import Locator from "widgets/locator/locator";
-import BootstrapMap from "widgets/bootstrapmap/bootstrapmap";
+import Locator from "../locator/locator";
+import BootstrapMap from "../bootstrapmap/bootstrapmap";
     export default declare([_WidgetBase, _TemplatedMixin], {
         templateString: dijitTemplate,
         lastWebMapSelected: "",

--- a/js/widgets/help/help.js
+++ b/js/widgets/help/help.js
@@ -15,24 +15,14 @@
 | See the License for the specific language governing permissions and
 | limitations under the License.
 */
-define([
-    "dojo/_base/declare",
-    "dojo/dom-construct",
-    "dojo/text!./templates/help.html",
-    "dijit/_WidgetBase",
-    "dijit/_TemplatedMixin",
-    "dijit/_WidgetsInTemplateMixin",
-    "dojo/domReady!"
-], function (
-    declare,
-    domConstruct,
-    template,
-    _WidgetBase,
-    _TemplatedMixin,
-    _WidgetsInTemplateMixin
-
-) {
-    return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
+import declare from "dojo/_base/declare";
+import domConstruct from "dojo/dom-construct";
+import template from "dojo/text!./templates/help.html";
+import _WidgetBase from "dijit/_WidgetBase";
+import _TemplatedMixin from "dijit/_TemplatedMixin";
+import _WidgetsInTemplateMixin from "dijit/_WidgetsInTemplateMixin";
+import "dojo/domReady!";
+    export default declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
         templateString: template,
 
         postCreate: function () {
@@ -57,4 +47,4 @@ define([
             }, 200);
         }
     });
-});
+

--- a/js/widgets/issue-wall/issue-wall.js
+++ b/js/widgets/issue-wall/issue-wall.js
@@ -36,7 +36,7 @@ import Graphic from "esri/graphic";
 import FeatureLayer from "esri/layers/FeatureLayer";
 import Query from "esri/tasks/query";
 import PopupTemplate from "esri/dijit/PopupTemplate";
-import ItemList from "widgets/item-list/item-list";
+import ItemList from "../item-list/item-list";
 import event from "dojo/_base/event";
     export default declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
         templateString: template,
@@ -473,4 +473,3 @@ import event from "dojo/_base/event";
             }));
         }
     });
-

--- a/js/widgets/issue-wall/issue-wall.js
+++ b/js/widgets/issue-wall/issue-wall.js
@@ -16,31 +16,29 @@
  | limitations under the License.
  */
 //============================================================================================================================//
-define([
-    "dojo/_base/declare",
-    "dojo/dom",
-    "dojo/dom-construct",
-    "dojo/dom-style",
-    "dojo/dom-attr",
-    "dojo/dom-class",
-    "dojo/_base/lang",
-    "dojo/_base/array",
-    "dojo/on",
-    "dojo/touch",
-    "dojo/string",
-    "dojo/query",
-    "dojo/text!./templates/issue-wall.html",
-    "dijit/_WidgetBase",
-    "dijit/_TemplatedMixin",
-    "dijit/_WidgetsInTemplateMixin",
-    "esri/graphic",
-    "esri/layers/FeatureLayer",
-    "esri/tasks/query",
-    "esri/dijit/PopupTemplate",
-    "widgets/item-list/item-list",
-    "dojo/_base/event"
-], function (declare, dom, domConstruct, domStyle, domAttr, domClass, lang, array, on, touch, string, query, template, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, Graphic, FeatureLayer, Query, PopupTemplate, ItemList, event) {
-    return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
+import declare from "dojo/_base/declare";
+import dom from "dojo/dom";
+import domConstruct from "dojo/dom-construct";
+import domStyle from "dojo/dom-style";
+import domAttr from "dojo/dom-attr";
+import domClass from "dojo/dom-class";
+import lang from "dojo/_base/lang";
+import array from "dojo/_base/array";
+import on from "dojo/on";
+import touch from "dojo/touch";
+import string from "dojo/string";
+import query from "dojo/query";
+import template from "dojo/text!./templates/issue-wall.html";
+import _WidgetBase from "dijit/_WidgetBase";
+import _TemplatedMixin from "dijit/_TemplatedMixin";
+import _WidgetsInTemplateMixin from "dijit/_WidgetsInTemplateMixin";
+import Graphic from "esri/graphic";
+import FeatureLayer from "esri/layers/FeatureLayer";
+import Query from "esri/tasks/query";
+import PopupTemplate from "esri/dijit/PopupTemplate";
+import ItemList from "widgets/item-list/item-list";
+import event from "dojo/_base/event";
+    export default declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
         templateString: template,
         _hasCommentsTable: false,
         _commentsTable: null,
@@ -475,4 +473,4 @@ define([
             }));
         }
     });
-});
+

--- a/js/widgets/item-details/item-details-controller.js
+++ b/js/widgets/item-details/item-details-controller.js
@@ -40,7 +40,7 @@ import _WidgetBase from 'dijit/_WidgetBase';
 import _TemplatedMixin from 'dijit/_TemplatedMixin';
 import DeferredList from 'dojo/DeferredList';
 import template from 'dojo/text!./templates/item-details-view.html';
-import CommentForm from "widgets/comment-form/comment-form";
+import CommentForm from "../comment-form/comment-form";
 import query from "dojo/query";
 
     export default declare([_WidgetBase, _TemplatedMixin], {
@@ -1082,4 +1082,3 @@ import query from "dojo/query";
             }), 100);
         }
     });
-

--- a/js/widgets/item-details/item-details-controller.js
+++ b/js/widgets/item-details/item-details-controller.js
@@ -15,64 +15,35 @@
  | See the License for the specific language governing permissions and
  | limitations under the License.
  */
-define([
-    'dojo/_base/declare',
-    'dojo/_base/lang',
-    'dojo/_base/array',
-    'dojo/dom-construct',
-    'dojo/dom-style',
-    'dojo/dom-class',
-    'dojo/dom-attr',
-    'dojo/query',
-    'dojo/on',
-    'dojo/dom',
-    'dojo/string',
-    'dojo/topic',
-    'dojo/touch',
-    'dojo/NodeList-dom',
-    'dojo/Deferred',
-    'esri/graphic',
-    'esri/dijit/PopupTemplate',
-    'esri/tasks/query',
-    'esri/tasks/QueryTask',
-    'esri/tasks/RelationshipQuery',
-    'dijit/layout/ContentPane',
-    'dijit/_WidgetBase',
-    'dijit/_TemplatedMixin',
-    'dojo/DeferredList',
-    'dojo/text!./templates/item-details-view.html',
-    "widgets/comment-form/comment-form",
-    "dojo/query"
-], function (declare,
-    lang,
-    arrayUtil,
-    domConstruct,
-    domStyle,
-    domClass,
-    domAttr,
-    dojoQuery,
-    on,
-    dom,
-    string,
-    topic,
-    touch,
-    nld,
-    Deferred,
-    Graphic,
-    PopupTemplate,
-    Query,
-    QueryTask,
-    RelationshipQuery,
-    ContentPane,
-    _WidgetBase,
-    _TemplatedMixin,
-    DeferredList,
-    template,
-    CommentForm,
-    query
-    ) {
+import declare from 'dojo/_base/declare';
+import lang from 'dojo/_base/lang';
+import arrayUtil from 'dojo/_base/array';
+import domConstruct from 'dojo/dom-construct';
+import domStyle from 'dojo/dom-style';
+import domClass from 'dojo/dom-class';
+import domAttr from 'dojo/dom-attr';
+import dojoQuery from 'dojo/query';
+import on from 'dojo/on';
+import dom from 'dojo/dom';
+import string from 'dojo/string';
+import topic from 'dojo/topic';
+import touch from 'dojo/touch';
+import nld from 'dojo/NodeList-dom';
+import Deferred from 'dojo/Deferred';
+import Graphic from 'esri/graphic';
+import PopupTemplate from 'esri/dijit/PopupTemplate';
+import Query from 'esri/tasks/query';
+import QueryTask from 'esri/tasks/QueryTask';
+import RelationshipQuery from 'esri/tasks/RelationshipQuery';
+import ContentPane from 'dijit/layout/ContentPane';
+import _WidgetBase from 'dijit/_WidgetBase';
+import _TemplatedMixin from 'dijit/_TemplatedMixin';
+import DeferredList from 'dojo/DeferredList';
+import template from 'dojo/text!./templates/item-details-view.html';
+import CommentForm from "widgets/comment-form/comment-form";
+import query from "dojo/query";
 
-    return declare([_WidgetBase, _TemplatedMixin], {
+    export default declare([_WidgetBase, _TemplatedMixin], {
         templateString: template,
         id: 'itemDetail',
         baseClass: 'esriCTItemDetail',
@@ -1111,4 +1082,4 @@ define([
             }), 100);
         }
     });
-});
+

--- a/js/widgets/item-list/item-list.js
+++ b/js/widgets/item-list/item-list.js
@@ -15,25 +15,21 @@
  | See the License for the specific language governing permissions and
  | limitations under the License.
  */
-define([
-    'dojo/_base/declare',
-    'dojo/_base/lang',
-    'dojo/_base/array',
-    'dojo/dom-construct',
-    'dojo/dom-style',
-    'dojo/dom-class',
-    'dojo/on',
-    'dojo/query',
-    'dojo/topic',
-    'dojo/NodeList-dom',
-    'dijit/_WidgetBase',
-    'dijit/_TemplatedMixin',
-    'dojo/text!./templates/item-list-view.html'
-], function (declare, lang, arrayUtil, domConstruct, domStyle, domClass, on, dojoQuery, topic, nld,
-    _WidgetBase, _TemplatedMixin,
-    template) {
+import declare from 'dojo/_base/declare';
+import lang from 'dojo/_base/lang';
+import arrayUtil from 'dojo/_base/array';
+import domConstruct from 'dojo/dom-construct';
+import domStyle from 'dojo/dom-style';
+import domClass from 'dojo/dom-class';
+import on from 'dojo/on';
+import dojoQuery from 'dojo/query';
+import topic from 'dojo/topic';
+import nld from 'dojo/NodeList-dom';
+import _WidgetBase from 'dijit/_WidgetBase';
+import _TemplatedMixin from 'dijit/_TemplatedMixin';
+import template from 'dojo/text!./templates/item-list-view.html';
 
-    return declare([_WidgetBase, _TemplatedMixin], {
+    export default declare([_WidgetBase, _TemplatedMixin], {
         templateString: template,
         showLikes: false,
         currentMap: null,
@@ -332,5 +328,5 @@ define([
             return evt;
         }
     });
-});
+
 

--- a/js/widgets/locator/locator.js
+++ b/js/widgets/locator/locator.js
@@ -1,39 +1,37 @@
 ﻿/*global define,dojo,alert,$ */
 /*jslint browser:true,sloppy:true,nomen:true,unparam:true,plusplus:true,indent:4 */
-define([
-    "dojo/_base/declare",
-    "dojo/dom-construct",
-    "dojo/_base/lang",
-    "dojo/dom-attr",
-    "dojo/dom-class",
-    "dojo/dom-geometry",
-    "dojo/dom-style",
-    "dojo/_base/array",
-    "dojo/dom",
-    "dojo/Deferred",
-    "dojo/DeferredList",
-    "dojo/on",
-    "dojo/keys",
-    "dojo/query",
-    "dojo/text!./templates/locator.html",
-    "dijit/_WidgetBase",
-    "dijit/_TemplatedMixin",
-    "dijit/_WidgetsInTemplateMixin",
-    "esri/Color",
-    "esri/config",
-    "esri/graphic",
-    "esri/geometry/Point",
-    "esri/geometry/webMercatorUtils",
-    "esri/layers/GraphicsLayer",
-    "esri/SpatialReference",
-    "esri/tasks/GeometryService",
-    "esri/tasks/locator",
-    "esri/tasks/ProjectParameters",
-    "esri/tasks/query",
-    "esri/tasks/QueryTask",
-    "vendor/usng"
-], function (declare, domConstruct, lang, domAttr, domClass, domGeom, domStyle, array, dom, Deferred, DeferredList, on, keys, query, template, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, Color, esriConfig, Graphic, Point, webMercatorUtils, GraphicsLayer, SpatialReference, GeometryService, Locator, ProjectParameters, EsriQuery, QueryTask, usng) {
-    return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
+import declare from "dojo/_base/declare";
+import domConstruct from "dojo/dom-construct";
+import lang from "dojo/_base/lang";
+import domAttr from "dojo/dom-attr";
+import domClass from "dojo/dom-class";
+import domGeom from "dojo/dom-geometry";
+import domStyle from "dojo/dom-style";
+import array from "dojo/_base/array";
+import dom from "dojo/dom";
+import Deferred from "dojo/Deferred";
+import DeferredList from "dojo/DeferredList";
+import on from "dojo/on";
+import keys from "dojo/keys";
+import query from "dojo/query";
+import template from "dojo/text!./templates/locator.html";
+import _WidgetBase from "dijit/_WidgetBase";
+import _TemplatedMixin from "dijit/_TemplatedMixin";
+import _WidgetsInTemplateMixin from "dijit/_WidgetsInTemplateMixin";
+import Color from "esri/Color";
+import esriConfig from "esri/config";
+import Graphic from "esri/graphic";
+import Point from "esri/geometry/Point";
+import webMercatorUtils from "esri/geometry/webMercatorUtils";
+import GraphicsLayer from "esri/layers/GraphicsLayer";
+import SpatialReference from "esri/SpatialReference";
+import GeometryService from "esri/tasks/GeometryService";
+import Locator from "esri/tasks/locator";
+import ProjectParameters from "esri/tasks/ProjectParameters";
+import EsriQuery from "esri/tasks/query";
+import QueryTask from "esri/tasks/QueryTask";
+import usng from "vendor/usng";
+    export default declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
         templateString: template,
         lastSearchString: null,
         stagedSearch: null,
@@ -811,4 +809,3 @@ define([
         }
 
     });
-});

--- a/js/widgets/map-search/map-search.js
+++ b/js/widgets/map-search/map-search.js
@@ -29,9 +29,9 @@ import string from "dojo/string";
 import dojowindow from "dojo/window";
 import ThemeCss from "dojo/text!css/theme-template.css";
 import GraphicsLayer from "esri/layers/GraphicsLayer";
-import ApplicationUtils from "application/utils/utils";
+import ApplicationUtils from "../../utils/utils";
 import query from "dojo/query";
-import Locator from "widgets/locator/locator";
+import Locator from "../locator/locator";
 import _WidgetBase from "dijit/_WidgetBase";
 import Graphic from "esri/graphic";
 import PictureMarkerSymbol from "esri/symbols/PictureMarkerSymbol";
@@ -216,4 +216,3 @@ import "dojo/domReady!";
             return feature;
         }
     });
-

--- a/js/widgets/map-search/map-search.js
+++ b/js/widgets/map-search/map-search.js
@@ -15,52 +15,28 @@
 | See the License for the specific language governing permissions and
 | limitations under the License.
 */
-define([
-    "dojo/_base/declare",
-    "dojo/_base/lang",
-    "esri/arcgis/utils",
-    "dojo/dom",
-    "dojo/dom-construct",
-    "dojo/dom-style",
-    "dojo/dom-class",
-    "dojo/dom-attr",
-    "dojo/on",
-    "dojo/topic",
-    "dojo/string",
-    "dojo/window",
-    "dojo/text!css/theme-template.css",
-    "esri/layers/GraphicsLayer",
-    "application/utils/utils",
-    "dojo/query",
-    "widgets/locator/locator",
-    "dijit/_WidgetBase",
-    "esri/graphic",
-    "esri/symbols/PictureMarkerSymbol",
-    "dojo/domReady!"
-], function (
-    declare,
-    lang,
-    arcgisUtils,
-    dom,
-    domConstruct,
-    domStyle,
-    domClass,
-    domAttr,
-    on,
-    topic,
-    string,
-    dojowindow,
-    ThemeCss,
-    GraphicsLayer,
-    ApplicationUtils,
-    query,
-    Locator,
-    _WidgetBase,
-    Graphic,
-    PictureMarkerSymbol
-
-) {
-    return declare([_WidgetBase], {
+import declare from "dojo/_base/declare";
+import lang from "dojo/_base/lang";
+import arcgisUtils from "esri/arcgis/utils";
+import dom from "dojo/dom";
+import domConstruct from "dojo/dom-construct";
+import domStyle from "dojo/dom-style";
+import domClass from "dojo/dom-class";
+import domAttr from "dojo/dom-attr";
+import on from "dojo/on";
+import topic from "dojo/topic";
+import string from "dojo/string";
+import dojowindow from "dojo/window";
+import ThemeCss from "dojo/text!css/theme-template.css";
+import GraphicsLayer from "esri/layers/GraphicsLayer";
+import ApplicationUtils from "application/utils/utils";
+import query from "dojo/query";
+import Locator from "widgets/locator/locator";
+import _WidgetBase from "dijit/_WidgetBase";
+import Graphic from "esri/graphic";
+import PictureMarkerSymbol from "esri/symbols/PictureMarkerSymbol";
+import "dojo/domReady!";
+    export default declare([_WidgetBase], {
         startup: function () {
             this.inherited(arguments);
         },
@@ -240,4 +216,4 @@ define([
             return feature;
         }
     });
-});
+

--- a/js/widgets/mobile-menu/mobile-menu.js
+++ b/js/widgets/mobile-menu/mobile-menu.js
@@ -16,28 +16,25 @@
  | limitations under the License.
  */
 //============================================================================================================================//
-define([
-    "dojo/_base/declare",
-    "dojo/dom-construct",
-    "dojo/dom-geometry",
-    "dojo/window",
-    "dojo/dom-style",
-    "dojo/dom-attr",
-    "dojo/dom-class",
-    "dojo/dom",
-    "dojo/_base/lang",
-    "dojo/topic",
-    "dojo/on",
-    "dojo/Deferred",
-    "dojo/promise/all",
-    "esri/arcgis/Portal",
-    "dojo/text!./templates/mobile-menu.html",
-    "dijit/_WidgetBase",
-    "dijit/_TemplatedMixin",
-    "dijit/_WidgetsInTemplateMixin"
-
-], function (declare, domConstruct, domGeom, win, domStyle, domAttr, domClass, dom, lang, topic, on, Deferred, all, esriPortal, template, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin) {
-    return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
+import declare from "dojo/_base/declare";
+import domConstruct from "dojo/dom-construct";
+import domGeom from "dojo/dom-geometry";
+import win from "dojo/window";
+import domStyle from "dojo/dom-style";
+import domAttr from "dojo/dom-attr";
+import domClass from "dojo/dom-class";
+import dom from "dojo/dom";
+import lang from "dojo/_base/lang";
+import topic from "dojo/topic";
+import on from "dojo/on";
+import Deferred from "dojo/Deferred";
+import all from "dojo/promise/all";
+import esriPortal from "esri/arcgis/Portal";
+import template from "dojo/text!./templates/mobile-menu.html";
+import _WidgetBase from "dijit/_WidgetBase";
+import _TemplatedMixin from "dijit/_TemplatedMixin";
+import _WidgetsInTemplateMixin from "dijit/_WidgetsInTemplateMixin";
+    export default declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
         templateString: template,
         _lastSelectedView: null,
         config: {
@@ -206,4 +203,4 @@ define([
             return evt;
         }
     });
-});
+

--- a/js/widgets/my-issues/my-issues.js
+++ b/js/widgets/my-issues/my-issues.js
@@ -16,32 +16,30 @@
  | limitations under the License.
  */
 //============================================================================================================================//
-define([
-    "dojo/_base/declare",
-    "dojo/Deferred",
-    "dojo/dom",
-    "dojo/dom-construct",
-    "dojo/dom-style",
-    "dojo/dom-attr",
-    "dojo/dom-class",
-    "dojo/_base/array",
-    "dojo/_base/lang",
-    "dojo/on",
-    "dojo/string",
-    "dojo/query",
-    "dojo/text!./templates/my-issues.html",
-    "dojo/promise/all",
-    "dijit/_WidgetBase",
-    "dijit/_TemplatedMixin",
-    "dijit/_WidgetsInTemplateMixin",
-    "esri/arcgis/utils",
-    "esri/graphic",
-    "esri/layers/FeatureLayer",
-    "esri/tasks/QueryTask",
-    "esri/tasks/query",
-    "widgets/item-list/item-list"
-], function (declare, Deferred, dom, domConstruct, domStyle, domAttr, domClass, array, lang, on, string, query, template, all, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, arcgisUtils, Graphic, FeatureLayer, QueryTask, Query, ItemList) {
-    return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
+import declare from "dojo/_base/declare";
+import Deferred from "dojo/Deferred";
+import dom from "dojo/dom";
+import domConstruct from "dojo/dom-construct";
+import domStyle from "dojo/dom-style";
+import domAttr from "dojo/dom-attr";
+import domClass from "dojo/dom-class";
+import array from "dojo/_base/array";
+import lang from "dojo/_base/lang";
+import on from "dojo/on";
+import string from "dojo/string";
+import query from "dojo/query";
+import template from "dojo/text!./templates/my-issues.html";
+import all from "dojo/promise/all";
+import _WidgetBase from "dijit/_WidgetBase";
+import _TemplatedMixin from "dijit/_TemplatedMixin";
+import _WidgetsInTemplateMixin from "dijit/_WidgetsInTemplateMixin";
+import arcgisUtils from "esri/arcgis/utils";
+import Graphic from "esri/graphic";
+import FeatureLayer from "esri/layers/FeatureLayer";
+import QueryTask from "esri/tasks/QueryTask";
+import Query from "esri/tasks/query";
+import ItemList from "widgets/item-list/item-list";
+    export default declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
         templateString: template,
         opLayersArr: [],
         isNoFeatureFound: null,
@@ -516,4 +514,3 @@ define([
             }
         }
     });
-});

--- a/js/widgets/my-issues/my-issues.js
+++ b/js/widgets/my-issues/my-issues.js
@@ -38,7 +38,7 @@ import Graphic from "esri/graphic";
 import FeatureLayer from "esri/layers/FeatureLayer";
 import QueryTask from "esri/tasks/QueryTask";
 import Query from "esri/tasks/query";
-import ItemList from "widgets/item-list/item-list";
+import ItemList from "../item-list/item-list";
     export default declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
         templateString: template,
         opLayersArr: [],

--- a/js/widgets/sidebar-content-controller/sidebar-content-controller.js
+++ b/js/widgets/sidebar-content-controller/sidebar-content-controller.js
@@ -16,26 +16,15 @@
  | limitations under the License.
  */
 //============================================================================================================================//
-define([
-    "dojo/_base/declare",
-    "dijit/_WidgetBase",
-    "dijit/_TemplatedMixin",
-    "dojo/text!./templates/sidebar-content-controller-view.html",
-    "dojo/_base/lang",
-    "dojo/dom",
-    "dojo/dom-style",
-    "dojo/on"
-], function (
-    declare,
-    _WidgetBase,
-    _TemplatedMixin,
-    template,
-    lang,
-    dom,
-    domStyle,
-    on
-) {
-    return declare([_WidgetBase, _TemplatedMixin], {
+import declare from "dojo/_base/declare";
+import _WidgetBase from "dijit/_WidgetBase";
+import _TemplatedMixin from "dijit/_TemplatedMixin";
+import template from "dojo/text!./templates/sidebar-content-controller-view.html";
+import lang from "dojo/_base/lang";
+import dom from "dojo/dom";
+import domStyle from "dojo/dom-style";
+import on from "dojo/on";
+    export default declare([_WidgetBase, _TemplatedMixin], {
         templateString: template,
         _panels: {},
         _currentPanelName: null,
@@ -116,4 +105,4 @@ define([
         }
 
     });
-});
+

--- a/js/widgets/sign-in/facebook-helper.js
+++ b/js/widgets/sign-in/facebook-helper.js
@@ -15,14 +15,12 @@
  | See the License for the specific language governing permissions and
  | limitations under the License.
  */
-define([
-    "dojo/_base/declare",
-    "dojo/on",
-    "dojo/_base/lang",
-    "dojo/query",
-    "dojo/dom-class"
-], function (declare, on, lang, query, domClass) {
-    return declare(null, {
+import declare from "dojo/_base/declare";
+import on from "dojo/on";
+import lang from "dojo/_base/lang";
+import query from "dojo/query";
+import domClass from "dojo/dom-class";
+    export default declare(null, {
         _config: null,
         FBLoggedIn: false,
         userDetails: { fullName: null, firstName: null, lastName: null, uniqueID: null, socialMediaType: null },
@@ -113,4 +111,3 @@ define([
             return userDetails;
         }
     });
-});

--- a/js/widgets/sign-in/sign-in.js
+++ b/js/widgets/sign-in/sign-in.js
@@ -16,34 +16,31 @@
  | limitations under the License.
  */
 //============================================================================================================================//
-define([
-    "config/template-config",
-    "application/template",
-    "application/main",
-    "dojo/_base/declare",
-    "dojo/dom-construct",
-    "dojo/dom-style",
-    "dojo/dom-attr",
-    "dojo/dom-class",
-    "dojo/_base/lang",
-    "dojo/_base/array",
-    "dojo/on",
-    "dojo/dom",
-    "dojo/Deferred",
-    "dojo/promise/all",
-    "esri/arcgis/Portal",
-    "dojo/text!./templates/sign-in.html",
-    "dijit/_WidgetBase",
-    "dijit/_TemplatedMixin",
-    "dijit/_WidgetsInTemplateMixin",
-    "esri/IdentityManager",
-    "widgets/sign-in/facebook-helper",
-    "widgets/sign-in/twitter-helper",
-    "widgets/help/help",
-    "dojo/query"
-
-], function (templateConfig, MainTemplate, Main, declare, domConstruct, domStyle, domAttr, domClass, lang, array, on, dom, Deferred, all, esriPortal, template, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, IdentityManager, FBHelper, TWHelper, Help, query) {
-    return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
+import templateConfig from "config/template-config";
+import MainTemplate from "application/template";
+import Main from "application/main";
+import declare from "dojo/_base/declare";
+import domConstruct from "dojo/dom-construct";
+import domStyle from "dojo/dom-style";
+import domAttr from "dojo/dom-attr";
+import domClass from "dojo/dom-class";
+import lang from "dojo/_base/lang";
+import array from "dojo/_base/array";
+import on from "dojo/on";
+import dom from "dojo/dom";
+import Deferred from "dojo/Deferred";
+import all from "dojo/promise/all";
+import esriPortal from "esri/arcgis/Portal";
+import template from "dojo/text!./templates/sign-in.html";
+import _WidgetBase from "dijit/_WidgetBase";
+import _TemplatedMixin from "dijit/_TemplatedMixin";
+import _WidgetsInTemplateMixin from "dijit/_WidgetsInTemplateMixin";
+import IdentityManager from "esri/IdentityManager";
+import FBHelper from "widgets/sign-in/facebook-helper";
+import TWHelper from "widgets/sign-in/twitter-helper";
+import Help from "widgets/help/help";
+import query from "dojo/query";
+    export default declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
         templateString: template,
         _config: null,
         _boilerPlateTemplate: null,
@@ -469,4 +466,3 @@ define([
             }
         }
     });
-});

--- a/js/widgets/sign-in/sign-in.js
+++ b/js/widgets/sign-in/sign-in.js
@@ -16,9 +16,9 @@
  | limitations under the License.
  */
 //============================================================================================================================//
-import templateConfig from "config/template-config";
-import MainTemplate from "application/template";
-import Main from "application/main";
+import templateConfig from "../../../template-config";
+import MainTemplate from "../../template";
+import Main from "../../main";
 import declare from "dojo/_base/declare";
 import domConstruct from "dojo/dom-construct";
 import domStyle from "dojo/dom-style";
@@ -36,9 +36,9 @@ import _WidgetBase from "dijit/_WidgetBase";
 import _TemplatedMixin from "dijit/_TemplatedMixin";
 import _WidgetsInTemplateMixin from "dijit/_WidgetsInTemplateMixin";
 import IdentityManager from "esri/IdentityManager";
-import FBHelper from "widgets/sign-in/facebook-helper";
-import TWHelper from "widgets/sign-in/twitter-helper";
-import Help from "widgets/help/help";
+import FBHelper from "../sign-in/facebook-helper";
+import TWHelper from "../sign-in/twitter-helper";
+import Help from "../help/help";
 import query from "dojo/query";
     export default declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
         templateString: template,
@@ -85,7 +85,7 @@ import query from "dojo/query";
         */
         _handleSplashScreenVisibility: function () {
             var isSplashScreenRequired = false;
-            //Check for all social media sign in options and decide wehter to show splash screen or not 
+            //Check for all social media sign in options and decide wehter to show splash screen or not
             if (this._config.enableGuestAccess || this._config.enableFacebook ||
                      this._config.enableTwitter || this._config.enableGoogleplus
                     || this._config.enablePortalLogin) {

--- a/js/widgets/sign-in/twitter-helper.js
+++ b/js/widgets/sign-in/twitter-helper.js
@@ -15,13 +15,11 @@
  | See the License for the specific language governing permissions and
  | limitations under the License.
  */
-define([
-    "dojo/_base/declare",
-    "dojo/on",
-    "esri/request",
-    "dojo/_base/lang"
-], function (declare, on, esriRequest, lang) {
-    return declare(null, {
+import declare from "dojo/_base/declare";
+import on from "dojo/on";
+import esriRequest from "esri/request";
+import lang from "dojo/_base/lang";
+    export default declare(null, {
         _config: null,
         TWLoggedIn: false,
         userDetails: {
@@ -138,4 +136,3 @@ define([
             return userDetails;
         }
     });
-});

--- a/js/widgets/webmap-list/webmap-list.js
+++ b/js/widgets/webmap-list/webmap-list.js
@@ -15,58 +15,31 @@
  | See the License for the specific language governing permissions and
  | limitations under the License.
  */
-define([
-    "dojo/_base/declare",
-    "dojo/_base/lang",
-    "dojo/_base/array",
-    "dijit/_WidgetBase",
-    "dijit/_TemplatedMixin",
-    "dojo/text!./templates/webmap-list.html",
-    "dojo/dom-construct",
-    "dojo/DeferredList",
-    "dojo/text!./templates/webmap-item.html",
-    "dojo/text!./templates/operational-layer.html",
-    "dojo/_base/event",
-    "dojo/string",
-    "dojo/dom-attr",
-    "dojo/on",
-    "esri/layers/FeatureLayer",
-    "dojo/dom",
-    "dojo/dom-class",
-    'dojo/dom-style',
-    'dojo/aspect',
-    "widgets/bootstrapmap/bootstrapmap",
-    "dijit/_WidgetsInTemplateMixin",
-    "dojo/query",
-    "esri/geometry/Extent",
-    "esri/geometry/Point"
-], function (
-    declare,
-    lang,
-    array,
-    _WidgetBase,
-    _TemplatedMixin,
-    dijitTemplate,
-    domConstruct,
-    DeferredList,
-    webMapItemTemplate,
-    operationalLayerTemplate,
-    event,
-    string,
-    domAttr,
-    on,
-    FeatureLayer,
-    dom,
-    domClass,
-    domStyle,
-    aspect,
-    BootstrapMap,
-    _WidgetsInTemplateMixin,
-    query,
-    Extent,
-    Point
-) {
-    return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
+import declare from "dojo/_base/declare";
+import lang from "dojo/_base/lang";
+import array from "dojo/_base/array";
+import _WidgetBase from "dijit/_WidgetBase";
+import _TemplatedMixin from "dijit/_TemplatedMixin";
+import dijitTemplate from "dojo/text!./templates/webmap-list.html";
+import domConstruct from "dojo/dom-construct";
+import DeferredList from "dojo/DeferredList";
+import webMapItemTemplate from "dojo/text!./templates/webmap-item.html";
+import operationalLayerTemplate from "dojo/text!./templates/operational-layer.html";
+import event from "dojo/_base/event";
+import string from "dojo/string";
+import domAttr from "dojo/dom-attr";
+import on from "dojo/on";
+import FeatureLayer from "esri/layers/FeatureLayer";
+import dom from "dojo/dom";
+import domClass from "dojo/dom-class";
+import domStyle from 'dojo/dom-style';
+import aspect from 'dojo/aspect';
+import BootstrapMap from "widgets/bootstrapmap/bootstrapmap";
+import _WidgetsInTemplateMixin from "dijit/_WidgetsInTemplateMixin";
+import query from "dojo/query";
+import Extent from "esri/geometry/Extent";
+import Point from "esri/geometry/Point";
+    export default declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
         templateString: dijitTemplate,
         filteredWebMapResponseArr: [], // to store web-map that needs to be displayed in list
         lastWebMapSelected: "", // used to store last web map that is selected
@@ -850,4 +823,3 @@ define([
             return;
         }
     });
-});

--- a/js/widgets/webmap-list/webmap-list.js
+++ b/js/widgets/webmap-list/webmap-list.js
@@ -34,7 +34,7 @@ import dom from "dojo/dom";
 import domClass from "dojo/dom-class";
 import domStyle from 'dojo/dom-style';
 import aspect from 'dojo/aspect';
-import BootstrapMap from "widgets/bootstrapmap/bootstrapmap";
+import BootstrapMap from "../bootstrapmap/bootstrapmap";
 import _WidgetsInTemplateMixin from "dijit/_WidgetsInTemplateMixin";
 import query from "dojo/query";
 import Extent from "esri/geometry/Extent";


### PR DESCRIPTION
1. Run `amdtoes6 --dir js/ --out js/`
2. Change `import` paths so they use relative paths instead of dojo's package namespaces